### PR TITLE
게시글 상세 조회 서비스 기능 수정

### DIFF
--- a/backend/src/main/java/org/example/backend/controller/board/BoardDetailController.java
+++ b/backend/src/main/java/org/example/backend/controller/board/BoardDetailController.java
@@ -168,15 +168,16 @@ public class BoardDetailController {
     }
 
     // 첨부파일 다운로드
-    @GetMapping("/file-download/{uuid}")
+    // http://localhost:9000/api/board/file/upload/545bf1a1c15d44c5be214492693aab79
+    // <img src="http://localhost:9000/api/board/file/upload/545bf1a1c15d44c5be214492693aab79"
+    // <a href="http://localhost:9000/api/board/file/upload/545bf1a1c15d44c5be214492693aab79" >이미지</a>
+    @GetMapping("/file/upload/{uuid}")
     public ResponseEntity<byte[]> fileDownload(@PathVariable String uuid) {
         File file = boardDetailService.fileDownload(uuid).get();
         return ResponseEntity.ok()
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + file.getFileName() + "\"")
                 .body(file.getData()); // BLOB 데이터
     }
-
-
 
     // 글번호로 댓글 조회
     @GetMapping("/board-detail/reply")
@@ -229,12 +230,12 @@ public class BoardDetailController {
             @RequestParam(defaultValue = "") Long boardId,
             @RequestParam(defaultValue = "") String memberId,
             @RequestParam(defaultValue = "") String reply,
-            @RequestParam(defaultValue = "") Long reReply,
+            @RequestParam(required = false) Long reReply,
             @RequestPart(value = "file", required = false) MultipartFile file
     ) {
         try {
             ReplyDto replyDto = new ReplyDto(null, boardId, memberId, reply, reReply);
-            log.debug("ReplyDto :::: ", replyDto);
+            log.debug("ReplyDto :::: {}", replyDto);
             replyService.saveReply(replyDto, file);
             return new ResponseEntity<>("댓글 저장 성공", HttpStatus.OK);
         } catch (Exception e) {
@@ -243,15 +244,23 @@ public class BoardDetailController {
     }
 
     // 댓글 수정
-//    @PutMapping("/board-detail/reply")
-//    public ResponseEntity<Object> updateReply(@RequestParam Long replyId, @RequestBody Reply reply) {
-//        try {
-//            replyService.saveReplyFile(reply);
-//            return new ResponseEntity<>("댓글 수정 성공", HttpStatus.OK);
-//        } catch (Exception e) {
-//            return handleException(e);
-//        }
-//    }
+    @PutMapping("/board-detail/reply/{replyId}")
+    public ResponseEntity<Object> updateReply(
+            @PathVariable Long replyId,
+            @RequestParam(defaultValue = "") Long boardId,
+            @RequestParam(defaultValue = "") String memberId,
+            @RequestParam(defaultValue = "") String reply,
+            @RequestParam(required = false) Long reReply,
+            @RequestPart(value = "file", required = false) MultipartFile file) {
+        try {
+            ReplyDto replyDto = new ReplyDto(replyId, boardId, memberId, reply, reReply);
+            log.debug("ReplyDto :::: {}", replyDto);
+            replyService.updateReply(replyDto, file);
+            return new ResponseEntity<>("댓글 수정 성공", HttpStatus.OK);
+        } catch (Exception e) {
+            return handleException(e);
+        }
+    }
 
     // 글 신고 데이터 저장
     @PostMapping("/board-detail/report")
@@ -324,7 +333,7 @@ public class BoardDetailController {
     @DeleteMapping("board-detail/delete/{boardId}")
     public ResponseEntity<?> deleteBoard(@PathVariable Long boardId) {
         try {
-            log.debug(":"+ boardId);
+            log.debug(":" + boardId);
             boardDetailService.deleteBoard(boardId);
             return ResponseEntity.ok("게시글 삭제가 완료되었습니다.");
         } catch (Exception e) {

--- a/backend/src/main/java/org/example/backend/model/dto/board/Reply/ReplyDto.java
+++ b/backend/src/main/java/org/example/backend/model/dto/board/Reply/ReplyDto.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 
 /**
  * packageName : org.example.backend.model.dto.board.Reply
- * fileName : ReplyUploadDto
+ * fileName : ReplyDto
  * author : SAMSUNG
  * date : 2024-06-10
  * description :

--- a/backend/src/main/java/org/example/backend/repository/board/BoardDetailRepository.java
+++ b/backend/src/main/java/org/example/backend/repository/board/BoardDetailRepository.java
@@ -82,7 +82,7 @@ public interface BoardDetailRepository extends JpaRepository<Board, Long> {
     @Query(value = "SELECT BF.BOARD_ID AS boardId,\n" +
             "              F.UUID AS uuid,\n" +
             "              F.FILE_URL AS fileUrl,\n" +
-            "F.FILE_NAME AS fileName " +
+            "              F.FILE_NAME AS fileName " +
             "        FROM TB_BOARD_FILE BF, TB_FILE F\n" +
             "        WHERE BF.UUID = F.UUID\n" +
             "        AND BF.BOARD_ID = :boardId"

--- a/backend/src/main/java/org/example/backend/service/board/ReplyService.java
+++ b/backend/src/main/java/org/example/backend/service/board/ReplyService.java
@@ -64,7 +64,7 @@ public class ReplyService {
         return count;
     }
 
-    // 댓글 저장/수정
+    // 댓글 저장
     @Transactional
     public Reply saveReply(ReplyDto replyDto, MultipartFile file) {
         // DTO -> Entity 매핑
@@ -105,7 +105,39 @@ public class ReplyService {
         return reply;
     }
 
-    // 댓글 관리 테이블에 저장
+
+
+    // 댓글 수정
+    @Transactional
+    public Reply updateReply(ReplyDto replyDto, MultipartFile file) {
+
+        // replyId로 기존 댓글 찾기
+        Reply reply = replyRepository.findById(replyDto.getReplyId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 댓글이 존재하지 않습니다. replyId: " + replyDto.getReplyId()));
+
+        modelMapper.map(replyDto, reply);
+
+        // Reply 저장
+        reply.setBoardId(replyDto.getBoardId());
+        reply.setMemberId(replyDto.getMemberId());
+        reply.setReply(replyDto.getReply());
+        reply.setReReply(replyDto.getReReply());
+        replyRepository.save(reply);
+
+        // File, ReplyFile 저장
+        if (file != null && !file.isEmpty()) {
+            File file2 = saveReplyFile(null, file);
+
+            ReplyFile replyFile = modelMapper.map(replyDto, ReplyFile.class);
+
+            replyFile.setReplyId(reply.getReplyId());
+            replyFile.setUuid(file2.getUuid());
+            replyFileRepository.save(replyFile);
+        }
+
+        return reply;
+    }
+
 
 
     // 댓글 파일 첨부 저장
@@ -119,16 +151,16 @@ public class ReplyService {
                         .replace("-", "");
 
                 String fileDownload = ServletUriComponentsBuilder
-                        .fromCurrentContextPath()               // spring 기본주소 : http://localhost:8000
+                        .fromCurrentContextPath()               // spring 기본주소 : http://localhost:9000
                         .path("/api/board/file/upload/")        // 추가 경로 넣기
                         .path(tmpUuid)                          // uuid 넣기
                         .toUriString();                         // 합치기
                 // File 객체 생성(생성자, setter) + save()
                 File file1 = new File(
                         tmpUuid,                        // 기존 uuid
-                        fileDownload,                // 파일 다운로드 url
-                        file.getOriginalFilename(),  // 업로드 할때 파일명
-                        file.getBytes()              // 업로드 이미지
+                        fileDownload,                   // 파일 다운로드 url
+                        file.getOriginalFilename(),     // 업로드 할때 파일명
+                        file.getBytes()                 // 업로드 이미지
                 );
                 file2 = fileRepository.save(file1);  // DB 수정
 
@@ -136,8 +168,8 @@ public class ReplyService {
                 replyFile.setUuid(file2.getUuid());
             } else {
                 String fileDownload = ServletUriComponentsBuilder
-                        .fromCurrentContextPath()           // spring 기본주소 : http://localhost:8000
-                        .path("/api/board/file/upload/")           // 추가 경로 넣기
+                        .fromCurrentContextPath()           // spring 기본주소
+                        .path("/api/board/file/upload/")    // 추가 경로 넣기
                         .path(uuid)                         // uuid 넣기
                         .toUriString();                     // 합치기
                 // File 객체 생성(생성자, setter) + save()

--- a/frontend-vue/src/services/board/BoardDetailService.js
+++ b/frontend-vue/src/services/board/BoardDetailService.js
@@ -39,7 +39,6 @@ class BoardDetailService {
       headers: LoginHeader(),
     });
   }
-
   // 글번호로 이미지 조회
   getImg(boardId) {
     return http.get(`/board/board-detail/board-img?boardId=${boardId}`);

--- a/frontend-vue/src/services/board/ReplyService.js
+++ b/frontend-vue/src/services/board/ReplyService.js
@@ -10,25 +10,16 @@ class ReplyService {
   }
   // 대댓글 조회
   getReReply(boardId, replyId) {
-    return http.get(`/board/board-detail/re-reply?boardId=${boardId}&replyId=${replyId}`, {
+    return http.get(
+      `/board/board-detail/re-reply?boardId=${boardId}&replyId=${replyId}`,
+      {
         headers: LoginHeader(),
-      });
+      }
+    );
   }
   // 댓글 수 조회
   getReplyCount(boardId) {
     return http.get(`/board/board-detail/reply/count?boardId=${boardId}`, {
-      headers: LoginHeader(),
-    });
-  }
-  // 댓글 등록
-  // createReply(data) {
-  //   return http.post(`/board/board-detail/reply`, data, {
-  //     headers: LoginHeader(),
-  //   });
-  // }
-  // 댓글 수정
-  updateReply(replyId, data) {
-    return http.put(`/board/board-detail/reply?replyId=${replyId}`, data, {
       headers: LoginHeader(),
     });
   }
@@ -39,7 +30,7 @@ class ReplyService {
     });
   }
 
-  // 댓글 + 파일 저장
+  // 댓글(대댓글) + 파일 저장
   createReply(temp, file) {
     let formData = new FormData(); // form 객체
     // formData.append("replyDto", JSON.stringify(temp));
@@ -61,6 +52,24 @@ class ReplyService {
     });
   }
 
+  // 댓글 수정
+  updateReply(temp, file) {
+    let formData = new FormData(); // form 객체
+    // formData.append("boardId", temp.boardId);
+    // formData.append("memberId", temp.memberId);
+    formData.append("reply", temp.reply);
+    // formData.append("reReply", temp.reReply);
+    formData.append("file", file);
+
+    //formData 로그
+    for (const x of formData) {
+      console.log("formData ::: ", x);
+    }
+
+    return http.put(`/board/board-detail/reply/${temp.replyId}`, formData, {
+      headers: LoginHeader(),
+    });
+  }
 }
 
 export default new ReplyService();

--- a/frontend-vue/src/views/board/DeptBoardDetailView.vue
+++ b/frontend-vue/src/views/board/DeptBoardDetailView.vue
@@ -41,44 +41,46 @@
             <div class="modal-dialog">
                 <div class="modal-content">
                     <form class="was-validated">
-                    <div class="modal-header">
-                        <h1 class="modal-title fs-5" id="reportModalLabel">게시글 신고</h1>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                    </div>
-                    <div class="modal-body">
-                        <div class="mb-2 row">
-                            <label for="staticWriter" class="col-sm-2 col-form-label">작성자</label>
-                            <div class="col-sm-10">
-                                <input type="text" readonly class="form-control-plaintext" id="staticWriter"
-                                    v-model="board.memberName">
-                            </div>
+                        <div class="modal-header">
+                            <h1 class="modal-title fs-5" id="reportModalLabel">게시글 신고</h1>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                         </div>
-                        <div class="mb-2 row">
-                            <label for="staticTitle" class="col-sm-2 col-form-label">내용</label>
-                            <div class="col-sm-10">
-                                <input type="text" readonly class="form-control-plaintext" id="staticTitle"
-                                    v-model="board.boardTitle">
+                        <div class="modal-body">
+                            <div class="mb-2 row">
+                                <label for="staticWriter" class="col-sm-2 col-form-label">작성자</label>
+                                <div class="col-sm-10">
+                                    <input type="text" readonly class="form-control-plaintext" id="staticWriter"
+                                        v-model="board.memberName">
+                                </div>
                             </div>
-                        </div>
-                        <div class="mb-2">
-                            <hr />
-                            
+                            <div class="mb-2 row">
+                                <label for="staticTitle" class="col-sm-2 col-form-label">내용</label>
+                                <div class="col-sm-10">
+                                    <input type="text" readonly class="form-control-plaintext" id="staticTitle"
+                                        v-model="board.boardTitle">
+                                </div>
+                            </div>
+                            <div class="mb-2">
+                                <hr />
                                 <textarea rows="10" class="form-control" placeholder="신고 사유를 입력하세요." required
-                                    v-model="reportReason"></textarea>
+                                    v-model.lazy="reportReason"></textarea>
                                 <div class="invalid-feedback">
                                     신고 사유는 필수 입력값입니다.
                                 </div>
-                            
+                            </div>
                         </div>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>
-                        <button type="submit" class="btn btn-danger" @click="createReport">신고</button>
-                    </div>
-                </form>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>
+                            <button type="submit" class="btn btn-danger" @click="createReport">신고</button>
+                        </div>
+                    </form>
                 </div>
             </div>
         </div>
+
+
+
+
 
 
 
@@ -89,10 +91,10 @@
         <div class="reply-content mb-3">
             <ul v-for="(data, index) in reply" :key="index" class="list-group mb-3">
                 <!-- 댓글 -->
-                <li v-if="replyUpdate" class="list-group-item">
+                <li v-if="data.replyId" class="list-group-item">
                     <div class="reply-name">{{ data.memberName }}</div>
                     <div class="reply-content">{{ data.reply }}</div>
-                    <img v-if="data.fileUrl" :src="data.fileUrl" class="img-fluid" alt="이미지" />
+                    <img v-if="data.fileUrl" :src="data.fileUrl" class="img-fluid img-thumbnail w-25" alt="이미지" />
                     <div class="d-flex justify-content-between mt-2">
                         <div class="reply-date">{{ data.addDate }}</div>
                         <div>
@@ -105,48 +107,42 @@
                         </div>
                     </div>
                     <button class="btn btn-secondary mt-2" @click="openReReply(data.replyId)">대댓글쓰기</button>
-
-
-
                     <!-- 대댓글 작성 폼 (대댓글쓰기 버튼 클릭 시 나타남) -->
                     <div v-if="showWriteReReply && parentId === data.replyId" class="card mb-3 mt-3">
                         <div class="card-body">
                             <div class="reply-name">{{ memberInfo.memberName }} (익명게시판은 별명으로 변경하세요)</div>
-                            <textarea v-model="reReplyTextarea" placeholder="대댓글을 남겨보세요"
+                            <textarea v-model.lazy="reReplyTextarea" placeholder="대댓글을 남겨보세요"
                                 class="form-control mb-2 reply-content"></textarea>
                             <div class="d-flex justify-content-between">
                                 <!-- 파일첨부 -->
-                                <input class="form-control file-upload-input" type="file" @change="selectReReplyFile($event)" />
+                                <input class="form-control file-upload-input w-auto" type="file"
+                                    @change="selectReReplyFile($event)" />
                                 <button class="btn btn-primary file-upload-button"
                                     @click="createReReply(data.replyId)">등록</button>
                             </div>
                         </div>
                     </div>
-
-
-
                 </li>
                 <!-- 댓글 수정 버튼 클릭 시 보일 부분 -->
-                <li v-if="!replyUpdate" class="list-group-item">
+                <li v-if="replyUpdate && replyUpdateId === data.replyId" class="list-group-item">
                     <div class="reply-name">{{ data.memberName }} </div>
-                    <textarea v-model="data.reply" placeholder="댓글을 남겨보세요"
+                    <textarea v-model.lazy="data.reply" placeholder="댓글을 남겨보세요"
                         class="form-control mb-2 reply-content"></textarea>
-                    <div v-if="data.fileUrl" class="d-flex">
+                    <div class="d-flex">
                         <!-- 파일첨부 -->
-                        <input class="form-control file-upload-input mb-2" type="file" ref="replyFile"
-                            @change="selectReplyFile" /> {{ data.fileUrl }}
+                        <input class="form-control file-upload-input w-auto mb-2" type="file" ref="replyFile"
+                            @change="selectReplyFile" />
                     </div>
                     <div class="d-flex justify-content-between">
                         <button class="btn btn-secondary" @click="replyUpdate = true">취소</button>
                         <button class="btn btn-secondary" @click="updateReply(data)">등록</button>
                     </div>
                 </li>
-
                 <!-- 대댓글 -->
                 <li v-for="(reReply, index) in data.reReplies" :key="index" class="list-group-item reReply-container">
                     <div class="reply-name"><i class="bi bi-arrow-return-right"></i> {{ reReply.memberName }} </div>
                     <div class="reply-content">{{ reReply.reply }}</div>
-                    <img v-if="reReply.fileUrl" :src="reReply.fileUrl" class="img-fluid" alt="이미지" />
+                    <img v-if="reReply.fileUrl" :src="reReply.fileUrl" class="img-fluid img-thumbnail w-25" alt="이미지" />
                     <div class="d-flex justify-content-between mt-2">
                         <div class="reply-date">{{ reReply.addDate }}</div>
                         <div>
@@ -165,15 +161,23 @@
 
 
 
+
+
+
+
+
+
+
+
         <!-- 댓글 작성 -->
         <div class="card mb-3">
             <div class="card-body">
                 <div class="reply-name">{{ memberInfo.memberName }} (익명게시판은 별명으로 변경하세요)</div>
-                <textarea v-model="replyTextarea" placeholder="댓글을 남겨보세요"
+                <textarea v-model.lazy="replyTextarea" placeholder="댓글을 남겨보세요"
                     class="form-control mb-2 reply-content"></textarea>
                 <div class="d-flex justify-content-between">
                     <!-- 파일첨부 -->
-                    <input class="form-control file-upload-input" type="file" ref="replyFile"
+                    <input class="form-control file-upload-input w-auto" type="file" ref="replyFile"
                         @change="selectReplyFile" />
                     <button class="btn btn-primary file-upload-button" @click="createReply">등록</button>
                 </div>
@@ -198,16 +202,17 @@ export default {
             boardId: this.$route.params.boardId,    // 현재 글 ID 가져오기
             smcode: this.$route.params.smcode,      // 현재 소메뉴 코드 가져오기
 
-            auth: '', // 로그인 사용자 권한 체크
+            auth: "",                     // 로그인 사용자 권한 체크
             replyTextarea: "",
             reReplyTextarea: "",
-            parentId: "",               // 현재 대댓글의 상위 댓글의 replyId
-            recommendIcon: true,        // 추천 아이콘 (true는 빈 아이콘)
-            reportReason: "",           // 신고사유 입력
-            replyUpdate: true,          // false일 경우 수정란 뜸
-            currentFile: undefined,         // 댓글파일선택
+            parentId: "",                 // 현재 대댓글의 상위 댓글의 replyId
+            replyUpdateId: null,          // 현재 수정 중인 댓글 ID
+            recommendIcon: true,          // 추천 아이콘 (true는 빈 아이콘)
+            reportReason: "",             // 신고사유 입력
+            replyUpdate: false,            // true 이면 댓글 수정란 보이게
+            currentFile: undefined,       // 댓글파일선택
             currentReFile: undefined,     // 대댓글파일선택
-            showWriteReReply: false,
+            showWriteReReply: false,      // 대댓글쓰기
 
             // retrieve 
             memberInfo: "", // 회원정보
@@ -225,12 +230,14 @@ export default {
     methods: {
         // 회원 권한 체크
         async checkAuth() {
-            if (this.member.memberCode === "AT01") {
+            if (this.member?.memberCode === "AT01") {
                 // 관리자 로그인
                 this.auth = "A";
-            } else if (this.member.memberId === this.board.memberId) {
-                // 글쓴이 로그인
-                this.auth = "B";
+            } else if (this.member?.memberCode === "AT02") {
+                if (this.member?.memberId === this.board?.memberId) {
+                    // 글쓴이 로그인
+                    this.auth = "B";
+                }
             } else {
                 // 기타 회원
                 this.auth = "C";
@@ -242,6 +249,7 @@ export default {
                 let response = await BoardDetailService.getMember(this.member.memberId);
                 this.memberInfo = response.data;
                 console.log("memberInfo 데이터 : ", response.data);
+                this.checkAuth();
             } catch (e) {
                 console.log("retrieveMember 에러", e);
             }
@@ -266,11 +274,11 @@ export default {
                 console.log("retrieveCode 에러", e);
             }
         },
-        // 글번호로 투표 가져오기
+        // ❎ 글번호로 투표 가져오기
         async retrieveVote() {
 
         },
-        // 글번호로 장소 가져오기
+        // ❎ 글번호로 장소 가져오기
         async retrievePlace() {
 
         },
@@ -411,9 +419,6 @@ export default {
         },
 
 
-
-
-
         // 댓글 파일 선택상자에서 파일 선택
         selectReplyFile() {
             this.currentFile = this.$refs.replyFile.files[0];
@@ -426,6 +431,7 @@ export default {
                     boardId: this.boardId,
                     memberId: this.member.memberId,
                     reply: this.replyTextarea,
+                    reReply: ""
                 }
                 let response = await ReplyService.createReply(temp, this.currentFile);
                 console.log("댓글 전송 : ", response);
@@ -439,11 +445,6 @@ export default {
                 console.log(e);
             }
         },
-
-
-
-
-
         // 대댓글 쓰기 버튼 클릭 시 호출
         openReReply(replyId) {
             this.parentId = replyId;     // 현재 댓글ID를 저장
@@ -481,20 +482,17 @@ export default {
 
 
         // ❎ 댓글 수정 버튼 클릭 시 호출
-        openReplyUpdate() {
-            this.replyUpdate = !this.replyUpdate;
+        openReplyUpdate(replyId) {
+            this.replyUpdate = true;
+            this.replyUpdateId = replyId;
         },
         // ❎ 댓글 수정 후 등록
         async updateReply(data) {
             try {
                 let temp = {
-                    replyId: data.replyId,
-                    boardId: data.boardId,
-                    memberId: data.memberId,
-                    reReply: data.reReply,
                     reply: data.reply
                 }
-                let response = await ReplyService.updateReply(data.replyId, temp);
+                let response = await ReplyService.updateReply(temp, this.currentFile);
                 alert("댓글이 수정되었습니다.");
                 console.log("댓글 수정 : ", response.data);
                 this.retrieveReply();
@@ -503,8 +501,6 @@ export default {
                 console.log("updateReply 에러", e);
             }
         },
-
-
         // 글 수정 페이지로 이동
         moveToDeptEdit() {
             this.$router.push(`/board/dept-edit/${this.smcode}/${this.boardId}`);
@@ -618,7 +614,7 @@ export default {
 
 /* 파일 업로드 input */
 .file-upload-input {
-    width: 600px;
+    /* width: 600px; */
 }
 
 /* 파일 업로드 버튼 */


### PR DESCRIPTION
📌 게시글 이미지 조회(여러개)
📌 투표 조회  (-> 이건 동호회쪽 코드 가져오면됨)
📌 지도 조회 (-> 이건 동호회쪽 코드 가져오면됨)
✅ 댓글/대댓글 이미지 조회(1개) 
📌 댓글/대댓글 수정 (이미지포함)
📌 댓글/대댓글 삭제 (이미지포함)

📌 프론트 버튼 별 권한 적용
📌 프론트 수정 버튼 클릭 시, 버튼 클릭한 댓글만 수정창으로 바뀌게 해야함.


(+) 댓글 등록 시 url 포함 전송