### PR TITLE
게시글 상세 조회 기능 추가

### DIFF
--- a/backend/src/main/java/org/example/backend/controller/board/BoardDetailController.java
+++ b/backend/src/main/java/org/example/backend/controller/board/BoardDetailController.java
@@ -223,7 +223,7 @@ public class BoardDetailController {
         }
     }
 
-    // 댓글 저장
+    // 댓글 및 대댓글 저장
     @PostMapping("/board-detail/reply")
     public ResponseEntity<Object> createReply(
             @RequestParam(defaultValue = "") Long boardId,
@@ -242,7 +242,7 @@ public class BoardDetailController {
         }
     }
 
-    // ❎ 댓글 수정
+    // 댓글 및 대댓글 수정
     @PutMapping("/board-detail/reply")
     public ResponseEntity<Object> updateReply(
             @RequestParam(defaultValue = "") Long replyId,
@@ -256,6 +256,19 @@ public class BoardDetailController {
             log.debug("댓글 수정 ReplyDto :::: {}", replyDto);
             replyService.updateReply(replyDto, file);
             return new ResponseEntity<>("댓글 수정 성공", HttpStatus.OK);
+        } catch (Exception e) {
+            return handleException(e);
+        }
+    }
+
+    // 댓글 및 대댓글 삭제
+    @DeleteMapping("/board-detail/reply/delete")
+    public ResponseEntity<Object> deleteReply(@RequestParam Long replyId) {
+        try {
+            // DB 삭제 서비스 실행
+            log.debug("컨트롤러 실행 ::: ", replyId);
+            replyService.removeReply(replyId);
+            return new ResponseEntity<>("댓글 삭제 성공", HttpStatus.OK);
         } catch (Exception e) {
             return handleException(e);
         }
@@ -312,7 +325,7 @@ public class BoardDetailController {
         }
     }
 
-    // 게시글, 작성자 정보 상세 조회 / 수정 / 삭제
+    // 게시글, 작성자 정보 상세 조회
     @GetMapping("/board-detail/edit")
     public ResponseEntity<Object> findByBoardAndMember(@RequestParam Long boardId) {
         log.debug("Received boardId: {}", boardId);
@@ -328,7 +341,6 @@ public class BoardDetailController {
         }
     }
 
-
     @DeleteMapping("/board-detail/delete/{boardId}")
     public ResponseEntity<?> deleteBoard(@PathVariable Long boardId) {
         try {
@@ -340,7 +352,7 @@ public class BoardDetailController {
         }
     }
 
-    @PutMapping("board-detail/update/{boardId}")
+    @PutMapping("/board-detail/update/{boardId}")
     public ResponseEntity<?> updateBoard(@RequestParam Long boardId, @RequestBody IBoardDto boardDto) {
         try {
             boardDetailService.updateBoard(boardId, boardDto);

--- a/backend/src/main/java/org/example/backend/model/dto/board/IReplyDto.java
+++ b/backend/src/main/java/org/example/backend/model/dto/board/IReplyDto.java
@@ -21,7 +21,7 @@ public interface IReplyDto {
     String getMemberId();   // 회원 ID
     String getMemberName();   // 이름
     String getNickname();   // 닉네임
-    Long getReReplyId();    // 대댓글 ID
+    Long getReReply();    // 대댓글 ID
     String getReply();      // 댓글내용
     String getAddDate();    // 작성일
     String getFileUrl();    // 파일 URL

--- a/backend/src/main/java/org/example/backend/model/entity/board/Reply.java
+++ b/backend/src/main/java/org/example/backend/model/entity/board/Reply.java
@@ -9,6 +9,9 @@ import org.example.backend.model.common.BaseTimeEntity2;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 @Entity
 @Table(name = "TB_REPLY")
 @SequenceGenerator(
@@ -22,7 +25,7 @@ import org.hibernate.annotations.Where;
 @AllArgsConstructor
 @Where(clause = "STATUS = 'Y'")
 @SQLDelete(sql = "UPDATE TB_REPLY SET STATUS = 'N', DEL_DATE = TO_CHAR(SYSDATE, 'YYYY-MM-DD HH24:MI:SS') WHERE REPLY_ID = ?")
-public class Reply extends BaseTimeEntity2 {
+public class Reply {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE
             , generator = "TB_REPLY_SEQ_GENERATOR")
@@ -31,4 +34,28 @@ public class Reply extends BaseTimeEntity2 {
     private String memberId;     // 댓글작성자 fk
     private Long reReply;        // 대댓글 fk
     private String reply;        // 내용
+
+
+
+    private String addDate;
+    private String modDate;
+    private String delDate;
+    private String status;
+
+    @PrePersist
+    void OnPrePersist() {
+        this.addDate = LocalDateTime.now()
+                .format(DateTimeFormatter
+                        .ofPattern("yyyy-MM-dd HH:mm:ss"));
+        this.status = "Y";
+    }
+
+    @PreUpdate
+    void OnPreUpdate() {
+        this.modDate = LocalDateTime.now()
+                .format(DateTimeFormatter
+                        .ofPattern("yyyy-MM-dd HH:mm:ss"));
+        this.addDate = this.modDate;
+        this.status = "Y";
+    }
 }

--- a/backend/src/main/java/org/example/backend/repository/board/ReplyFileRepository.java
+++ b/backend/src/main/java/org/example/backend/repository/board/ReplyFileRepository.java
@@ -23,4 +23,5 @@ import java.util.List;
 public interface ReplyFileRepository extends JpaRepository<ReplyFile, Long> {
     void deleteByUuid(String uuid);
     List<ReplyFile> findByReplyId(Long replyId);
+
 }

--- a/backend/src/main/java/org/example/backend/repository/board/ReplyRepository.java
+++ b/backend/src/main/java/org/example/backend/repository/board/ReplyRepository.java
@@ -33,7 +33,7 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
             "        R.MEMBER_ID AS memberId,\n" +
             "        M.MEMBER_NAME AS memberName,\n" +
             "        M.NICKNAME AS nickname,\n" +
-            "        R.RE_REPLY AS reReplyId,\n" +
+            "        R.RE_REPLY AS reReply,\n" +
             "        R.REPLY AS reply,\n" +
             "        R.ADD_DATE AS addDate,\n" +
             "        F.FILE_URL AS fileUrl,\n" +
@@ -55,7 +55,7 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
             "        R.MEMBER_ID AS memberId,\n" +
             "        M.MEMBER_NAME AS memberName,\n" +
             "        M.NICKNAME AS nickname,\n" +
-            "        R.RE_REPLY AS reReplyId,\n" +
+            "        R.RE_REPLY AS reReply,\n" +
             "        R.REPLY AS reply,\n" +
             "        R.ADD_DATE AS addDate,\n" +
             "        F.FILE_URL AS fileUrl,\n" +

--- a/backend/src/main/java/org/example/backend/service/board/ReplyService.java
+++ b/backend/src/main/java/org/example/backend/service/board/ReplyService.java
@@ -92,8 +92,6 @@ public class ReplyService {
             replyFileRepository.save(replyFile);
         }
 
-
-
         // 댓글 알림
 //        Long boardId = replyDto.getBoardId();
 //        NotifyDto notifyDto = new NotifyDto();
@@ -128,10 +126,10 @@ public class ReplyService {
         // 기존 파일 삭제 로직
         List<ReplyFile> existingFiles = replyFileRepository.findByReplyId(reply.getReplyId());
         for (ReplyFile existingFile : existingFiles) {
-            // File 에서 삭제
-            deleteFile(existingFile.getUuid());
             // ReplyFile 에서 파일 정보 삭제
             replyFileRepository.delete(existingFile);
+            // File 에서 삭제
+            deleteFile(existingFile.getUuid());
         }
 
         replyRepository.save(reply);
@@ -149,7 +147,7 @@ public class ReplyService {
         return reply;
     }
 
-    // File 테이블에서 파일 삭제
+    // File 테이블에서 파일 삭제 (hard delete)
     public void deleteFile(String uuid) {
         if(fileRepository.existsById(uuid) == true) {
             // hard delete
@@ -204,7 +202,6 @@ public class ReplyService {
         return file2;
     }
 
-
     // 댓글 신고 데이터 저장
     public ReplyReport saveReplyReport(ReplyReport replyReport) {
         ReplyReport replyReport2 = replyReportRepository.save(replyReport);
@@ -215,10 +212,13 @@ public class ReplyService {
     @Transactional
     public void removeReply(Long replyId) {
         List<IDelReplyDto> delReply = replyRepository.findByReplyId(replyId);
+        log.debug("댓글 삭제 디버깅 111");
         for (IDelReplyDto replyDto : delReply) {
             if (replyDto.getUuid() != null) {
                 replyFileRepository.deleteByUuid(replyDto.getUuid());
+                log.debug("댓글 삭제 디버깅 222");
                 fileRepository.deleteById(replyDto.getUuid());
+                log.debug("댓글 삭제 디버깅 333");
             }
             replyRepository.deleteById(replyDto.getReplyId());
         }

--- a/frontend-vue/src/services/board/ReplyService.js
+++ b/frontend-vue/src/services/board/ReplyService.js
@@ -23,7 +23,8 @@ class ReplyService {
       headers: LoginHeader(),
     });
   }
-  // 신고 댓글 저장
+
+  // ❎ 신고 댓글 저장
   createReplyReport(report) {
     return http.post("/board/board-detail/reply-report", report, {
       headers: LoginHeader(),
@@ -51,8 +52,7 @@ class ReplyService {
       },
     });
   }
-
-  // 댓글 수정
+  // 댓글(대댓글) 수정
   updateReply(reply, file) {
     let formData = new FormData(); // form 객체
     formData.append("replyId", reply.replyId);
@@ -71,6 +71,13 @@ class ReplyService {
       headers: {
         "Content-Type": "multipart/form-data",
       },
+    });
+  }
+
+  // 댓글(대댓글) 삭제
+  deleteReply(replyId) {
+    return http.delete(`/board/board-detail/reply/delete?replyId=${replyId}`, {
+      headers: LoginHeader(),
     });
   }
 }


### PR DESCRIPTION
### ⚠️주요 변경 사항
- Reply 엔티티 필드 변경 : 댓글 수정 시 수정일시가 조회되도록 하기 위해서 변경
<br>

### ✅ 댓글 및 대댓글 CUD 테스트 
1) 댓글/대댓글 등록 (파일 첨부 x) 테스트 성공
2) 댓글/대댓글 등록 (파일 첨부 o) 테스트 성공
3) 댓글/대댓글 수정 (새 파일 첨부 후 등록) 테스트 성공
4) 댓글/대댓글 수정 (기존 파일 변경 후 등록) 테스트 성공
5) 댓글/대댓글 수정 (기존 파일 삭제 후 등록) 테스트 성공
6) 댓글/대댓글 삭제 테스트 성공 (✅대댓글 있을 시 삭제 못하도록 구현 : 댓글 신고쪽과 논의 필요)
<br>

### 📌 추가해야 할 기능
1) 회원 투표 기능 추가
2) 댓글 신고 기능 수정 필요
3) 게시글에 장소 정보 있을 시 조회
4) 권한 별 버튼 숨김 처리 기능 추가 (Front)